### PR TITLE
Enforce JWT secret configuration in production

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,9 @@
+# Implantação
+
+Para executar o aplicativo em produção, defina a variável de ambiente `JWT_SECRET` com um valor seguro:
+
+```bash
+export JWT_SECRET="sua_chave_secreta"
+```
+
+Sem essa configuração, o servidor lançará um erro ao iniciar em ambiente de produção.

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -19,6 +19,9 @@ const getJwtSecret = () => {
     if (secret && secret.length > 0) {
         return secret;
     }
+    if (process.env.NODE_ENV === 'production') {
+        throw new Error('JWT_SECRET não está definido no ambiente de produção.');
+    }
     console.warn('WARNING: JWT_SECRET environment variable not set or empty. Using a default, insecure key for development. This is NOT safe for production.');
     return 'your_default_secret_key_for_development';
 };


### PR DESCRIPTION
## Summary
- Throw error in `getJwtSecret` when `JWT_SECRET` is missing in production
- Add deployment docs to configure `JWT_SECRET`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aef9cc32b88330a4d80a573ff4f3c0