### PR TITLE
Fix login controller function closure

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -104,7 +104,8 @@ exports.login = async (req, res) => {
     message: 'Erro de servidor durante o login.',
     detail: error.message,           // 👈 mostra o motivo (ECONNREFUSED, self signed, relation não existe, etc.)
   });
-}
+  }
+};
 
 exports.register = async (req, res) => {
     const { name, email, password, role } = req.body;


### PR DESCRIPTION
## Summary
- close login controller with proper arrow function terminator

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aef71e78888330afbcc38dd5cddfe1