### PR TITLE
refactor: centralize jwt secret and improve registration

### DIFF
--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,8 +1,6 @@
 // src/middlewares/authMiddleware.js
 const jwt = require('jsonwebtoken');
-
-const getJwtSecret = () =>
-  process.env.JWT_SECRET || 'your_default_secret_key_for_development';
+const { getJwtSecret } = require('../utils/jwt');
 
 module.exports = (req, res, next) => {
   const authHeader = req.headers.authorization || '';
@@ -17,7 +15,7 @@ module.exports = (req, res, next) => {
   const token = authHeader.split(' ')[1];
 
   try {
-    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    const payload = jwt.verify(token, getJwtSecret());
 
     // payload pode vir como { id, role } ou { user: { id, role } }
     const u = payload.user || payload;

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,19 @@
+// src/utils/jwt.js
+// Centralized helper to obtain JWT secret.
+// In production, JWT_SECRET must be provided via environment variables.
+// In development, a weak default is used to avoid crashes but warns the user.
+const getJwtSecret = () => {
+  const secret = process.env.JWT_SECRET;
+  if (secret && secret.length > 0) return secret;
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('JWT_SECRET não está definido no ambiente de produção.');
+  }
+
+  console.warn(
+    'WARNING: JWT_SECRET não definido ou vazio. Usando uma chave INSEGURA de desenvolvimento. NÃO use isso em produção.'
+  );
+  return 'pikachu';
+};
+
+module.exports = { getJwtSecret };


### PR DESCRIPTION
## Summary
- centralize JWT secret retrieval logic
- default registration role to BROKER and validate case-insensitively
- use shared JWT helper in authentication middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af14ca2ecc8330afb050d56282acf3